### PR TITLE
fix(create-release): valid release sha checking if it is not valid

### DIFF
--- a/pkg/provider/git.go
+++ b/pkg/provider/git.go
@@ -164,8 +164,10 @@ func (repo *Repository) GetReleases(rawRe string) ([]*semrel.Release, error) {
 }
 
 func (repo *Repository) CreateRelease(release *provider.CreateReleaseConfig) error {
-	hash := plumbing.NewHash(release.SHA)
-	if hash.IsZero() {
+	var hash plumbing.Hash
+	if plumbing.IsHash(release.SHA) {
+		hash = plumbing.NewHash(release.SHA)
+	} else {
 		// hash is not valid, let's assume it is a branch name
 		resolvedRef, err := repo.repo.Reference(plumbing.NewBranchReferenceName(release.SHA), true)
 		if err != nil {


### PR DESCRIPTION
Previous version
```
hash := plumbing.NewHash(release.SHA)
```
for example, if `release.SHA = "dev"` will return `hash = "de000000..."`, so `hash.IsZero()` will not return `true` as it was supposed.

Now `release.SHA` is checked with `plumbing.IsHash(release.SHA)`.

Hope I fixed it)