### PR TITLE
Feat: allow to set tag prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ To use this plugin you need to include the following block in your
 | auth_private_key |                             | The path to an SSH private key file.               |
 | git_path         | .                           | The path to the Git repository.                    |
 | push_options     |                             | The push options for the git tag push.             |
+| tag_prefix       |                             | The tag prefix for the versions.                   |
 
 ### Authentication
 


### PR DESCRIPTION
This allows to set a tag prefix.

This is useful for example if the `go.mod` is is not in the git root folder.